### PR TITLE
Add configurable logging system to replace raw print statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Distribution / packaging
+.eggs/
+*.egg-info/
+*.egg
+
+# Virtual environments
+venv/
+ENV/
+env/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -7,6 +7,26 @@ I didn't find a SC16IS752 library for Micropython, so I ported a suitable lib fr
 
 There is also a small script **test_uart.py** which allows to test the lib with GM-60 or any other device which transmits smth to UART.
 
+## Logging
+
+The library includes a configurable logging system with the following levels:
+- `LOG_NONE` (0) - No logging output
+- `LOG_ERROR` (1) - Only error messages
+- `LOG_INFO` (2) - Info and error messages (default)
+- `LOG_DEBUG` (3) - All messages including debug
+
+To change the log level, use the `set_log_level()` function:
+
+```python
+from sc16is752 import SC16IS752, set_log_level, LOG_DEBUG, LOG_INFO, LOG_ERROR, LOG_NONE
+
+# Set to debug level to see all messages
+set_log_level(LOG_DEBUG)
+
+# Or disable all logging
+set_log_level(LOG_NONE)
+```
+
 ## How to connect stuff
 
 | SC16IS752	| ESP-32 |

--- a/sc16is752.py
+++ b/sc16is752.py
@@ -6,7 +6,7 @@
 from machine import Pin, I2C
 
 # Logging levels
-LOG_NONE = const(0)
+LOG_NONE = const(0)  # Threshold level: disables all logging
 LOG_ERROR = const(1)
 LOG_INFO = const(2)
 LOG_DEBUG = const(3)
@@ -15,6 +15,7 @@ LOG_DEBUG = const(3)
 _log_level = LOG_INFO
 
 # Level names dictionary (constant to avoid recreating on every call)
+# Note: LOG_NONE is not included as it's a threshold level, not a message level
 _LOG_LEVEL_NAMES = {LOG_ERROR: '[ERROR]', LOG_INFO: '[INFO]', LOG_DEBUG: '[DEBUG]'}
 
 def set_log_level(level):

--- a/sc16is752.py
+++ b/sc16is752.py
@@ -5,6 +5,27 @@
 
 from machine import Pin, I2C
 
+# Logging levels
+LOG_NONE = const(0)
+LOG_ERROR = const(1)
+LOG_INFO = const(2)
+LOG_DEBUG = const(3)
+
+# Global log level setting (can be changed by user)
+_log_level = LOG_INFO
+
+def set_log_level(level):
+    """Set the logging level. Use LOG_NONE, LOG_ERROR, LOG_INFO, or LOG_DEBUG."""
+    global _log_level
+    _log_level = level
+
+def _log(level, *args):
+    """Internal logging function."""
+    global _log_level
+    if level <= _log_level:
+        level_names = {LOG_ERROR: '[ERROR]', LOG_INFO: '[INFO]', LOG_DEBUG: '[DEBUG]'}
+        print(level_names.get(level, ''), *args)
+
 # Channel definitions
 SC16IS752_CHANNEL_A = const(0x00)
 SC16IS752_CHANNEL_B = const(0x01)
@@ -116,7 +137,7 @@ class SC16IS752():
 
     def txBufferSize(self):
 	    #  returns the number of empty spaces in the tx buffer, so 0 means it's full
-        print('TEXT BUFFER SIZE: ', self._readRegister(SC16IS752_TXLVL))
+        _log(LOG_DEBUG, 'TEXT BUFFER SIZE:', self._readRegister(SC16IS752_TXLVL))
 
         return self._readRegister(SC16IS752_TXLVL)
 
@@ -149,14 +170,14 @@ class SC16IS752():
     #  ----------------------------------- added by rsk -------
 
     def flush(self):
-        print('[INFO]:Flushing the buffer...')
+        _log(LOG_INFO, 'Flushing the buffer...')
         while self.available() > 0:
             self.read_byte()
 
 
     def SetBaudrate(self, baudrateDivisor):
         #  uses baud rate divisor from p17 of the datasheet.
-        print('[INFO]: Setting baud rate...')
+        _log(LOG_INFO, 'Setting baud rate...')
         temp_lcr = self._readRegister(SC16IS752_LCR)
         temp_lcr = self._bitwise_or_bytes(bytes(temp_lcr), b'\x80')
 
@@ -183,7 +204,7 @@ class SC16IS752():
 
 
     def FIFOEnable(self, fifo_enable):
-        print('[INFO]: Enabling FIFO...')
+        _log(LOG_INFO, 'Enabling FIFO...')
         temp_fcr = self._readRegister(SC16IS752_FCR)
 
         if fifo_enable == 0:
@@ -195,7 +216,7 @@ class SC16IS752():
 
 
     def SetLine(self, data_length, parity_select, stop_length):
-        print('[INFO]: Setting the line...')
+        _log(LOG_INFO, 'Setting the line...')
         temp_lcr = self._readRegister(SC16IS752_LCR)
         temp_lcr = self._bitwise_and_bytes(bytes(temp_lcr), b'\xC0') # Clear the lower six bit of LCR (LCR[0] to LCR[5]
 

--- a/sc16is752.py
+++ b/sc16is752.py
@@ -92,7 +92,7 @@ class SC16IS752():
         # note that << 3 shift, it is not documented but it gets the REAL address of a register
         # from the address listed in the manual, the same is for the channels
         result = self._i2c.readfrom_mem(self._deviceAddress, regAddress << 3 | self._channel << 1, 1)
-        #print('READ REGISTER', regAddress, 'RESULT: ', result)
+        _log(LOG_DEBUG, 'READ REGISTER', regAddress, 'RESULT:', result)
         return result
     
 
@@ -103,7 +103,7 @@ class SC16IS752():
             r = bytes([data])
         
         self._i2c.writeto_mem(self._deviceAddress, regAddress << 3 | self._channel << 1, r)
-        #print('WRITE REGISTER: ', regAddress << 3 | self._channel << 1, 'DATA: ', r)
+        _log(LOG_DEBUG, 'WRITE REGISTER:', regAddress << 3 | self._channel << 1, 'DATA:', r)
 
 
     def _uartConnected(self):
@@ -132,8 +132,8 @@ class SC16IS752():
   
         # This alternative just checks if there's data but doesn't
         # return how many characters are in the buffer:
-        # print('LSR register: ', self._readRegister(SC16IS752_LSR))
-        # print('The data stored in the receive buffer', self._bitwise_and_bytes(self._readRegister(SC16IS752_LSR), b'\x01'))
+        _log(LOG_DEBUG, 'LSR register:', self._readRegister(SC16IS752_LSR))
+        _log(LOG_DEBUG, 'The data stored in the receive buffer', self._bitwise_and_bytes(self._readRegister(SC16IS752_LSR), b'\x01'))
         
         return int.from_bytes(self._readRegister(SC16IS752_RXLVL), 'big')
 
@@ -186,10 +186,10 @@ class SC16IS752():
 
         self._writeRegister(SC16IS752_LCR, temp_lcr[0])
         # write to DLL
-        #print('SetBaudrate baudrateDivisor: ', baudrateDivisor)
+        _log(LOG_DEBUG, 'SetBaudrate baudrateDivisor:', baudrateDivisor)
         self._writeRegister(SC16IS752_DLL, baudrateDivisor)
         # write to DLH
-        #print('SetBaudrate baudrateDivisor>>8: ', baudrateDivisor>>8)
+        _log(LOG_DEBUG, 'SetBaudrate baudrateDivisor>>8:', baudrateDivisor>>8)
         self._writeRegister(SC16IS752_DLH, baudrateDivisor>>8)
 
         temp_lcr= self._bitwise_and_bytes(bytes(temp_lcr), b'\x7F')
@@ -202,7 +202,7 @@ class SC16IS752():
 
         reg = self._readRegister(SC16IS752_IOControl)
         reg = self._bitwise_or_bytes(bytes(reg), b'\x08')
-        # print('REG: ', reg)
+        _log(LOG_DEBUG, 'REG:', reg)
         self._writeRegister(SC16IS752_IOControl, reg[0])
 
 
@@ -223,8 +223,8 @@ class SC16IS752():
         temp_lcr = self._readRegister(SC16IS752_LCR)
         temp_lcr = self._bitwise_and_bytes(bytes(temp_lcr), b'\xC0') # Clear the lower six bit of LCR (LCR[0] to LCR[5]
 
-        #print("LCR Register:0x")
-        #print(temp_lcr)
+        _log(LOG_DEBUG, "LCR Register:0x")
+        _log(LOG_DEBUG, temp_lcr)
 
         # data length settings
         if data_length == 5:          

--- a/sc16is752.py
+++ b/sc16is752.py
@@ -14,6 +14,9 @@ LOG_DEBUG = const(3)
 # Global log level setting (can be changed by user)
 _log_level = LOG_INFO
 
+# Level names dictionary (constant to avoid recreating on every call)
+_LOG_LEVEL_NAMES = {LOG_ERROR: '[ERROR]', LOG_INFO: '[INFO]', LOG_DEBUG: '[DEBUG]'}
+
 def set_log_level(level):
     """Set the logging level. Use LOG_NONE, LOG_ERROR, LOG_INFO, or LOG_DEBUG."""
     global _log_level
@@ -23,8 +26,7 @@ def _log(level, *args):
     """Internal logging function."""
     global _log_level
     if level <= _log_level:
-        level_names = {LOG_ERROR: '[ERROR]', LOG_INFO: '[INFO]', LOG_DEBUG: '[DEBUG]'}
-        print(level_names.get(level, ''), *args)
+        print(_LOG_LEVEL_NAMES.get(level, ''), *args)
 
 # Channel definitions
 SC16IS752_CHANNEL_A = const(0x00)
@@ -137,9 +139,9 @@ class SC16IS752():
 
     def txBufferSize(self):
 	    #  returns the number of empty spaces in the tx buffer, so 0 means it's full
-        _log(LOG_DEBUG, 'TEXT BUFFER SIZE:', self._readRegister(SC16IS752_TXLVL))
-
-        return self._readRegister(SC16IS752_TXLVL)
+        result = self._readRegister(SC16IS752_TXLVL)
+        _log(LOG_DEBUG, 'TEXT BUFFER SIZE:', result)
+        return result
 
 
     def read_byte(self):

--- a/sc16is752.py
+++ b/sc16is752.py
@@ -223,8 +223,7 @@ class SC16IS752():
         temp_lcr = self._readRegister(SC16IS752_LCR)
         temp_lcr = self._bitwise_and_bytes(bytes(temp_lcr), b'\xC0') # Clear the lower six bit of LCR (LCR[0] to LCR[5]
 
-        _log(LOG_DEBUG, "LCR Register:0x")
-        _log(LOG_DEBUG, temp_lcr)
+        _log(LOG_DEBUG, 'LCR Register:0x', temp_lcr)
 
         # data length settings
         if data_length == 5:          


### PR DESCRIPTION
Replaced raw `print()` calls with a level-based logging system supporting `LOG_NONE`, `LOG_ERROR`, `LOG_INFO`, and `LOG_DEBUG`.

## Changes

- **Logging infrastructure** (sc16is752.py)
  - Added 4 log levels with `_log()` function checking level threshold before output
  - Default: `LOG_INFO` (preserves existing behavior)
  - Module-level constant `_LOG_LEVEL_NAMES` to avoid repeated allocations
  - Public API: `set_log_level(level)` for runtime control

- **Print statement replacements** (sc16is752.py)
  - `flush()`, `SetBaudrate()`, `FIFOEnable()`, `SetLine()` → `LOG_INFO`
  - `txBufferSize()` → `LOG_DEBUG`
  - Refactored `txBufferSize()` to avoid duplicate I2C reads when debug disabled
  - **Uncommented and converted 9 debug prints to `LOG_DEBUG` level:**
    - `_readRegister()`, `_writeRegister()` - register read/write operations
    - `available()` - LSR register and buffer data
    - `SetBaudrate()` - divisor values
    - `ResetDevice()`, `SetLine()` - register values

- **Documentation** (README.md)
  - Added logging section with usage examples

- **.gitignore**
  - Standard Python exclusions

## Usage

```python
from sc16is752 import SC16IS752, set_log_level, LOG_DEBUG, LOG_NONE

# Silent mode
set_log_level(LOG_NONE)

# Debug mode (shows all messages including low-level register operations)
set_log_level(LOG_DEBUG)
uart.txBufferSize()  # [DEBUG] TEXT BUFFER SIZE: ...
# Also shows: [DEBUG] READ REGISTER ... RESULT: ...
# And: [DEBUG] WRITE REGISTER: ... DATA: ...

# Default INFO mode (backward compatible)
set_log_level(LOG_INFO)
uart.SetBaudrate(12)  # [INFO] Setting baud rate...
```